### PR TITLE
Add php version requirement (7.0) to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         }
     ],
     "require": {
+        "php": ">=7.0",
         "smalot/pdfparser": "^0.10.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hello,

I think that you should add the minimum version of PHP in the composer.json to avoid people from installing your extension on php 5 projects.